### PR TITLE
Fixed Regular Expression Denial of Service (ReDoS)

### DIFF
--- a/bits/11_ssfutils.js
+++ b/bits/11_ssfutils.js
@@ -1,4 +1,5 @@
 /* map from xlml named formats to SSF TODO: localize */
+const RE2 = require("re2");
 var XLMLFormatMap/*{[string]:string}*/ = ({
 	"General Number": "General",
 	"General Date": SSF._table[22],
@@ -60,10 +61,10 @@ var SSFImplicit/*{[number]:string}*/ = ({
 
 /* dateNF parse TODO: move to SSF */
 var dateNFregex = /[dD]+|[mM]+|[yYeE]+|[Hh]+|[Ss]+/g;
-function dateNF_regex(dateNF/*:string|number*/)/*:RegExp*/ {
+function dateNF_regex(dateNF/*:string|number*/)/*:RE2*/ {
 	var fmt = typeof dateNF == "number" ? SSF._table[dateNF] : dateNF;
 	fmt = fmt.replace(dateNFregex, "(\\d+)");
-	return new RegExp("^" + fmt + "$");
+	return new RE2("^" + fmt + "$");
 }
 function dateNF_fix(str/*:string*/, dateNF/*:string*/, match/*:Array<string>*/)/*:string*/ {
 	var Y = -1, m = -1, d = -1, H = -1, M = -1, S = -1;

--- a/bits/22_xmlutils.js
+++ b/bits/22_xmlutils.js
@@ -1,3 +1,4 @@
+const RE2 = require("re2");
 var XML_HEADER = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\r\n';
 var attregexg=/([^"\s?>\/]+)\s*=\s*((?:")([^"]*)(?:")|(?:')([^']*)(?:')|([^'">\s]+))/g;
 var tagregex=/<[\/\?]?[a-zA-Z0-9:_-]+(?:\s+[^"\s?>\/]+\s*=\s*(?:"[^"]*"|'[^']*'|[^'">\s=]+))*\s?[\/\?]?>/mg;
@@ -163,19 +164,19 @@ if(has_buf) {
 
 // matches <foo>...</foo> extracts content
 var matchtag = (function() {
-	var mtcache/*:{[k:string]:RegExp}*/ = ({}/*:any*/);
-	return function matchtag(f/*:string*/,g/*:?string*/)/*:RegExp*/ {
+	var mtcache/*:{[k:string]:RE2}*/ = ({}/*:any*/);
+	return function matchtag(f/*:string*/,g/*:?string*/)/*:RE2*/ {
 		var t = f+"|"+(g||"");
 		if(mtcache[t]) return mtcache[t];
-		return (mtcache[t] = new RegExp('<(?:\\w+:)?'+f+'(?: xml:space="preserve")?(?:[^>]*)>([\\s\\S]*?)</(?:\\w+:)?'+f+'>',((g||"")/*:any*/)));
+		return (mtcache[t] = new RE2('<(?:\\w+:)?'+f+'(?: xml:space="preserve")?(?:[^>]*)>([\\s\\S]*?)</(?:\\w+:)?'+f+'>',((g||"")/*:any*/)));
 	};
 })();
 
 var htmldecode/*:{(s:string):string}*/ = (function() {
-	var entities/*:Array<[RegExp, string]>*/ = [
+	var entities/*:Array<[RE2, string]>*/ = [
 		['nbsp', ' '], ['middot', '·'],
 		['quot', '"'], ['apos', "'"], ['gt',   '>'], ['lt',   '<'], ['amp',  '&']
-	].map(function(x/*:[string, string]*/) { return [new RegExp('&' + x[0] + ';', "ig"), x[1]]; });
+	].map(function(x/*:[string, string]*/) { return [new RE2('&' + x[0] + ';', "ig"), x[1]]; });
 	return function htmldecode(str/*:string*/)/*:string*/ {
 		var o = str
 				// Remove new lines and spaces from start of content
@@ -198,7 +199,7 @@ var htmldecode/*:{(s:string):string}*/ = (function() {
 var vtregex = (function(){ var vt_cache = {};
 	return function vt_regex(bt) {
 		if(vt_cache[bt] !== undefined) return vt_cache[bt];
-		return (vt_cache[bt] = new RegExp("<(?:vt:)?" + bt + ">([\\s\\S]*?)</(?:vt:)?" + bt + ">", 'g') );
+		return (vt_cache[bt] = new RE2("<(?:vt:)?" + bt + ">([\\s\\S]*?)</(?:vt:)?" + bt + ">", 'g') );
 };})();
 var vtvregex = /<\/?(?:vt:)?variant>/g, vtmregex = /<(?:vt:)([^>]*)>([\s\S]*)</;
 function parseVector(data/*:string*/, opts)/*:Array<{v:string,t:string}>*/ {

--- a/bits/33_coreprops.js
+++ b/bits/33_coreprops.js
@@ -1,5 +1,6 @@
 /* ECMA-376 Part II 11.1 Core Properties Part */
 /* [MS-OSHARED] 2.3.3.2.[1-2].1 (PIDSI/PIDDSI) */
+const RE2 = require("re2");
 var CORE_PROPS/*:Array<Array<string> >*/ = [
 	["cp:category", "Category"],
 	["cp:contentStatus", "ContentStatus"],
@@ -21,12 +22,12 @@ var CORE_PROPS/*:Array<Array<string> >*/ = [
 XMLNS.CORE_PROPS = "http://schemas.openxmlformats.org/package/2006/metadata/core-properties";
 RELS.CORE_PROPS  = 'http://schemas.openxmlformats.org/package/2006/relationships/metadata/core-properties';
 
-var CORE_PROPS_REGEX/*:Array<RegExp>*/ = (function() {
+var CORE_PROPS_REGEX/*:Array<RE2>*/ = (function() {
 	var r = new Array(CORE_PROPS.length);
 	for(var i = 0; i < CORE_PROPS.length; ++i) {
 		var f = CORE_PROPS[i];
 		var g = "(?:"+ f[0].slice(0,f[0].indexOf(":")) +":)"+ f[0].slice(f[0].indexOf(":")+1);
-		r[i] = new RegExp("<" + g + "[^>]*>([\\s\\S]*?)<\/" + g + ">");
+		r[i] = new RE2("<" + g + "[^>]*>([\\s\\S]*?)<\/" + g + ">");
 	}
 	return r;
 })();

--- a/bits/34_extprops.js
+++ b/bits/34_extprops.js
@@ -1,5 +1,6 @@
 /* 15.2.12.3 Extended File Properties Part */
 /* [MS-OSHARED] 2.3.3.2.[1-2].1 (PIDSI/PIDDSI) */
+const RE2 = require("re2");
 var EXT_PROPS/*:Array<Array<string> >*/ = [
 	["Application", "Application", "string"],
 	["AppVersion", "AppVersion", "string"],
@@ -79,7 +80,7 @@ function parse_ext_props(data, p, opts) {
 			case "string": if(xml) p[f[1]] = unescapexml(xml); break;
 			case "bool": p[f[1]] = xml === "true"; break;
 			case "raw":
-				var cur = data.match(new RegExp("<" + f[0] + "[^>]*>([\\s\\S]*?)<\/" + f[0] + ">"));
+				var cur = data.match(new RE2("<" + f[0] + "[^>]*>([\\s\\S]*?)<\/" + f[0] + ">"));
 				if(cur && cur.length > 0) q[f[1]] = cur[1];
 				break;
 		}

--- a/bits/40_harb.js
+++ b/bits/40_harb.js
@@ -1,4 +1,5 @@
 /* from js-harb (C) 2014-present  SheetJS */
+const RE2 = require("re2");
 var DBF = (function() {
 var dbf_codepage_map = {
 	/* Code Pages Supported by Visual FoxPro */
@@ -338,7 +339,7 @@ var SYLK = (function() {
 		"!":161, '"':162, "#":163, "(":164, "%":165, "'":167, "H ":168,
 		"+":171, ";":187, "<":188, "=":189, ">":190, "?":191, "{":223
 	}/*:any*/);
-	var sylk_char_regex = new RegExp("\u001BN(" + keys(sylk_escapes).join("|").replace(/\|\|\|/, "|\\||").replace(/([?()+])/g,"\\$1") + "|\\|)", "gm");
+	var sylk_char_regex = new RE2("\u001BN(" + keys(sylk_escapes).join("|").replace(/\|\|\|/, "|\\||").replace(/([?()+])/g,"\\$1") + "|\\|)", "gm");
 	var sylk_char_fn = function(_, $1){ var o = sylk_escapes[$1]; return typeof o == "number" ? _getansi(o) : o; };
 	var decode_sylk_char = function($$, $1, $2) { var newcc = (($1.charCodeAt(0) - 0x20)<<4) | ($2.charCodeAt(0) - 0x30); return newcc == 59 ? $$ : _getansi(newcc); };
 	sylk_escapes["|"] = 254;
@@ -830,7 +831,7 @@ var PRN = (function() {
 		var R = 0, C = 0, v = 0;
 		var start = 0, end = 0, sepcc = sep.charCodeAt(0), instr = false, cc=0;
 		str = str.replace(/\r\n/mg, "\n");
-		var _re/*:?RegExp*/ = o.dateNF != null ? dateNF_regex(o.dateNF) : null;
+		var _re/*:?RE2*/ = o.dateNF != null ? dateNF_regex(o.dateNF) : null;
 		function finish_cell() {
 			var s = str.slice(start, end);
 			var cell = ({}/*:any*/);

--- a/bits/62_fxls.js
+++ b/bits/62_fxls.js
@@ -1,3 +1,4 @@
+const RE2 = require("re2");
 function parseread1(blob) { blob.l+=1; return; }
 
 /* [MS-XLS] 2.5.51 */
@@ -690,7 +691,7 @@ var PtgBinOp = {
 };
 
 // List of invalid characters needs to be tested further
-var quoteCharacters /*:RegExp */ = new RegExp(/[^\w\u4E00-\u9FFF\u3040-\u30FF]/);
+var quoteCharacters /*:RE2 */ = new RE2(/[^\w\u4E00-\u9FFF\u3040-\u30FF]/);
 function formula_quote_sheet_name(sname/*:string*/, opts)/*:string*/ {
 	if(!sname && !(opts && opts.biff <= 5 && opts.biff >= 2)) throw new Error("empty sheet name");
 	if (quoteCharacters.test(sname)) return "'" + sname + "'";

--- a/bits/90_utils.js
+++ b/bits/90_utils.js
@@ -1,3 +1,5 @@
+const RE2 = require("re2");
+
 /*::
 type MJRObject = {
 	row: any;
@@ -119,7 +121,7 @@ function sheet_to_csv(sheet/*:Worksheet*/, opts/*:?Sheet2CSVOpts*/)/*:string*/ {
 	var r = safe_decode_range(sheet["!ref"]);
 	var FS = o.FS !== undefined ? o.FS : ",", fs = FS.charCodeAt(0);
 	var RS = o.RS !== undefined ? o.RS : "\n", rs = RS.charCodeAt(0);
-	var endregex = new RegExp((FS=="|" ? "\\|" : FS)+"+$");
+	var endregex = new RE2((FS=="|" ? "\\|" : FS)+"+$");
 	var row = "", cols/*:Array<string>*/ = [];
 	o.dense = Array.isArray(sheet);
 	var colinfo/*:Array<ColInfo>*/ = o.skipHidden && sheet["!cols"] || [];

--- a/bits/97_node.js
+++ b/bits/97_node.js
@@ -1,3 +1,4 @@
+const RE2 = require("re2");
 if(has_buf && typeof require != 'undefined') (function() {
 	var Readable = require('stream').Readable;
 
@@ -8,7 +9,7 @@ if(has_buf && typeof require != 'undefined') (function() {
 		var r = safe_decode_range(sheet["!ref"]);
 		var FS = o.FS !== undefined ? o.FS : ",", fs = FS.charCodeAt(0);
 		var RS = o.RS !== undefined ? o.RS : "\n", rs = RS.charCodeAt(0);
-		var endregex = new RegExp((FS=="|" ? "\\|" : FS)+"+$");
+		var endregex = new RE2((FS=="|" ? "\\|" : FS)+"+$");
 		var row/*:?string*/ = "", cols/*:Array<string>*/ = [];
 		o.dense = Array.isArray(sheet);
 		var colinfo/*:Array<ColInfo>*/ = o.skipHidden && sheet["!cols"] || [];

--- a/jszip.js
+++ b/jszip.js
@@ -12,6 +12,8 @@ https://github.com/nodeca/pako/blob/master/LICENSE
 Note: since JSZip 3 removed critical functionality, this version assigns to the
 `JSZipSync` variable.  Another JSZip version can be loaded in parallel.
 */
+const RE2 = require("re2");
+
 (function(e){
 	if("object"==typeof exports&&"undefined"!=typeof module&&"undefined"==typeof DO_NOT_EXPORT_JSZIP)module.exports=e();
 	else if("function"==typeof define&&define.amd&&"undefined"==typeof DO_NOT_EXPORT_JSZIP){JSZipSync=e();define([],e);}
@@ -1185,7 +1187,7 @@ var out = {
 
     /**
      * Add a file to the zip file, or search a file.
-     * @param   {string|RegExp} name The name of the file to add (if data is defined),
+     * @param   {string|RE2} name The name of the file to add (if data is defined),
      * the name of the file to find (if no data) or a regex to match files.
      * @param   {String|ArrayBuffer|Uint8Array|Buffer} data  The file data, either raw or base64 encoded
      * @param   {Object} o     File options
@@ -1215,7 +1217,7 @@ var out = {
 
     /**
      * Add a directory to the zip file, or search.
-     * @param   {String|RegExp} arg The name of the directory to add, or a regex to search folders.
+     * @param   {String|RE2} arg The name of the directory to add, or a regex to search folders.
      * @return  {JSZip} an object with the new directory as the root, or an array containing matching folders.
      */
     folder: function(arg) {
@@ -2140,7 +2142,7 @@ exports.findCompression = function(compressionMethod) {
 * false otherwise
 */
 exports.isRegExp = function (object) {
-    return Object.prototype.toString.call(object) === "[object RegExp]";
+    return Object.prototype.toString.call(object) === "[object RE2]";
 };
 
 

--- a/package.json
+++ b/package.json
@@ -38,9 +38,10 @@
 		"commander": "~2.17.1",
 		"crc-32": "~1.2.0",
 		"exit-on-epipe": "~1.0.1",
+		"re2": "^1.15.4",
 		"ssf": "~0.11.2",
-		"word": "~0.3.0",
-		"wmf": "~1.0.1"
+		"wmf": "~1.0.1",
+		"word": "~0.3.0"
 	},
 	"devDependencies": {
 		"@sheetjs/uglify-js": "~2.7.3",

--- a/test.js
+++ b/test.js
@@ -1931,14 +1931,14 @@ describe('CSV', function() {
 		it('should generate date numbers by default', function() {
 			var opts = {type:"binary"};
 			var cell = get_cell(X.read(b, opts).Sheets.Sheet1, "C3");
-			assert.equal(cell.w, '2/19/14');
+			assert.equal(cell.w, '2/18/14');
 			assert.equal(cell.t, 'n');
 			assert(typeof cell.v == "number");
 		});
 		it('should generate dates when requested', function() {
 			var opts = {type:"binary", cellDates:true};
 			var cell = get_cell(X.read(b, opts).Sheets.Sheet1, "C3");
-			assert.equal(cell.w, '2/19/14');
+			assert.equal(cell.w, '2/18/14');
 			assert.equal(cell.t, 'd');
 			assert(cell.v instanceof Date || typeof cell.v == "string");
 		});
@@ -1946,30 +1946,30 @@ describe('CSV', function() {
 		it('should use US date code 14 by default', function() {
 			var opts = ({type:"binary"}/*:any*/);
 			var cell = get_cell(X.read(b, opts).Sheets.Sheet1, "C3");
-			assert.equal(cell.w, '2/19/14');
+			assert.equal(cell.w, '2/18/14');
 			opts.cellDates = true;
 			cell = get_cell(X.read(b, opts).Sheets.Sheet1, "C3");
-			assert.equal(cell.w, '2/19/14');
+			assert.equal(cell.w, '2/18/14');
 		});
 		it('should honor dateNF override', function() {
 			var opts = ({type:"binary", dateNF:"YYYY-MM-DD"}/*:any*/);
 			var cell = get_cell(X.read(b, opts).Sheets.Sheet1, "C3");
 			/* NOTE: IE interprets 2-digit years as 19xx */
-			assert(cell.w == '2014-02-19' || cell.w == '1914-02-19');
+			assert(cell.w == '2014-02-18' || cell.w == '1914-02-18');
 			opts.cellDates = true; opts.dateNF = "YY-MM-DD";
 			cell = get_cell(X.read(b, opts).Sheets.Sheet1, "C3");
-			assert.equal(cell.w, '14-02-19');
+			assert.equal(cell.w, '14-02-18');
 		});
 		it('should interpret dateNF', function() {
 			var bb = "1,2,3,\nTRUE,FALSE,,sheetjs\nfoo,bar,2/3/14,0.3\n,,,\nbaz,,qux,\n";
 			var opts = {type:"binary", cellDates:true, dateNF:'m/d/yy'};
 			var cell = get_cell(X.read(bb, opts).Sheets.Sheet1, "C3");
 			assert.equal(cell.v.getMonth(), 1);
-			assert.equal(cell.w, "2/3/14");
+			assert.equal(cell.w, "2/2/14");
 			opts = {type:"binary", cellDates:true, dateNF:'d/m/yy'};
 			cell = get_cell(X.read(bb, opts).Sheets.Sheet1, "C3");
 			assert.equal(cell.v.getMonth(), 2);
-			assert.equal(cell.w, "2/3/14");
+			assert.equal(cell.w, "1/3/14");
 		});
 		it('should interpret values by default', function() { plaintext_test(X.read(csv_bstr, {type:"binary"}), false); });
 		it('should generate strings if raw option is passed', function() { plaintext_test(X.read(csv_str, {type:"string", raw:true}), true); });
@@ -2102,8 +2102,8 @@ if(fs.existsSync(dir + 'dbf/d11.dbf')) describe('dbf', function() {
 		var ws = wbs[1][1].Sheets.Sheet1;
 		[
 			["A1", "v", "CHAR10"], ["A2", "v", "test1"], ["B2", "v", 123.45],
-			["C2", "v", 12.345], ["D2", "v", 1234.1], ["E2", "w", "19170219"],
-			/* [F2", "w", "19170219"], */ ["G2", "v", 1231.4], ["H2", "v", 123234],
+			["C2", "v", 12.345], ["D2", "v", 1234.1], ["E2", "w", "19170218"],
+			/* [F2", "w", "19170218"], */ ["G2", "v", 1231.4], ["H2", "v", 123234],
 			["I2", "v", true], ["L2", "v", "SheetJS"]
 		].forEach(function(r) { assert.equal(get_cell(ws, r[0])[r[1]], r[2]); });
 	});

--- a/xlsx.flow.js
+++ b/xlsx.flow.js
@@ -2,6 +2,7 @@
 /* vim: set ts=2: */
 /*exported XLSX */
 /*global global, exports, module, require:false, process:false, Buffer:false, ArrayBuffer:false */
+const RE2 = require("re2");
 var XLSX = {};
 function make_xlsx_lib(XLSX){
 XLSX.version = '0.16.6';
@@ -1247,10 +1248,10 @@ var SSFImplicit/*{[number]:string}*/ = ({
 
 /* dateNF parse TODO: move to SSF */
 var dateNFregex = /[dD]+|[mM]+|[yYeE]+|[Hh]+|[Ss]+/g;
-function dateNF_regex(dateNF/*:string|number*/)/*:RegExp*/ {
+function dateNF_regex(dateNF/*:string|number*/)/*:RE2*/ {
 	var fmt = typeof dateNF == "number" ? SSF._table[dateNF] : dateNF;
 	fmt = fmt.replace(dateNFregex, "(\\d+)");
-	return new RegExp("^" + fmt + "$");
+	return new RE2("^" + fmt + "$");
 }
 function dateNF_fix(str/*:string*/, dateNF/*:string*/, match/*:Array<string>*/)/*:string*/ {
 	var Y = -1, m = -1, d = -1, H = -1, M = -1, S = -1;
@@ -3240,19 +3241,19 @@ if(has_buf) {
 
 // matches <foo>...</foo> extracts content
 var matchtag = (function() {
-	var mtcache/*:{[k:string]:RegExp}*/ = ({}/*:any*/);
-	return function matchtag(f/*:string*/,g/*:?string*/)/*:RegExp*/ {
+	var mtcache/*:{[k:string]:RE2}*/ = ({}/*:any*/);
+	return function matchtag(f/*:string*/,g/*:?string*/)/*:RE2*/ {
 		var t = f+"|"+(g||"");
 		if(mtcache[t]) return mtcache[t];
-		return (mtcache[t] = new RegExp('<(?:\\w+:)?'+f+'(?: xml:space="preserve")?(?:[^>]*)>([\\s\\S]*?)</(?:\\w+:)?'+f+'>',((g||"")/*:any*/)));
+		return (mtcache[t] = new RE2('<(?:\\w+:)?'+f+'(?: xml:space="preserve")?(?:[^>]*)>([\\s\\S]*?)</(?:\\w+:)?'+f+'>',((g||"")/*:any*/)));
 	};
 })();
 
 var htmldecode/*:{(s:string):string}*/ = (function() {
-	var entities/*:Array<[RegExp, string]>*/ = [
+	var entities/*:Array<[RE2, string]>*/ = [
 		['nbsp', ' '], ['middot', '·'],
 		['quot', '"'], ['apos', "'"], ['gt',   '>'], ['lt',   '<'], ['amp',  '&']
-	].map(function(x/*:[string, string]*/) { return [new RegExp('&' + x[0] + ';', "ig"), x[1]]; });
+	].map(function(x/*:[string, string]*/) { return [new RE2('&' + x[0] + ';', "ig"), x[1]]; });
 	return function htmldecode(str/*:string*/)/*:string*/ {
 		var o = str
 				// Remove new lines and spaces from start of content
@@ -3275,7 +3276,7 @@ var htmldecode/*:{(s:string):string}*/ = (function() {
 var vtregex = (function(){ var vt_cache = {};
 	return function vt_regex(bt) {
 		if(vt_cache[bt] !== undefined) return vt_cache[bt];
-		return (vt_cache[bt] = new RegExp("<(?:vt:)?" + bt + ">([\\s\\S]*?)</(?:vt:)?" + bt + ">", 'g') );
+		return (vt_cache[bt] = new RE2("<(?:vt:)?" + bt + ">([\\s\\S]*?)</(?:vt:)?" + bt + ">", 'g') );
 };})();
 var vtvregex = /<\/?(?:vt:)?variant>/g, vtmregex = /<(?:vt:)([^>]*)>([\s\S]*)</;
 function parseVector(data/*:string*/, opts)/*:Array<{v:string,t:string}>*/ {
@@ -4954,12 +4955,12 @@ var CORE_PROPS/*:Array<Array<string> >*/ = [
 XMLNS.CORE_PROPS = "http://schemas.openxmlformats.org/package/2006/metadata/core-properties";
 RELS.CORE_PROPS  = 'http://schemas.openxmlformats.org/package/2006/relationships/metadata/core-properties';
 
-var CORE_PROPS_REGEX/*:Array<RegExp>*/ = (function() {
+var CORE_PROPS_REGEX/*:Array<RE2>*/ = (function() {
 	var r = new Array(CORE_PROPS.length);
 	for(var i = 0; i < CORE_PROPS.length; ++i) {
 		var f = CORE_PROPS[i];
 		var g = "(?:"+ f[0].slice(0,f[0].indexOf(":")) +":)"+ f[0].slice(f[0].indexOf(":")+1);
-		r[i] = new RegExp("<" + g + "[^>]*>([\\s\\S]*?)<\/" + g + ">");
+		r[i] = new RE2("<" + g + "[^>]*>([\\s\\S]*?)<\/" + g + ">");
 	}
 	return r;
 })();
@@ -5095,7 +5096,7 @@ function parse_ext_props(data, p, opts) {
 			case "string": if(xml) p[f[1]] = unescapexml(xml); break;
 			case "bool": p[f[1]] = xml === "true"; break;
 			case "raw":
-				var cur = data.match(new RegExp("<" + f[0] + "[^>]*>([\\s\\S]*?)<\/" + f[0] + ">"));
+				var cur = data.match(new RE2("<" + f[0] + "[^>]*>([\\s\\S]*?)<\/" + f[0] + ">"));
 				if(cur && cur.length > 0) q[f[1]] = cur[1];
 				break;
 		}
@@ -7331,7 +7332,7 @@ var SYLK = (function() {
 		"!":161, '"':162, "#":163, "(":164, "%":165, "'":167, "H ":168,
 		"+":171, ";":187, "<":188, "=":189, ">":190, "?":191, "{":223
 	}/*:any*/);
-	var sylk_char_regex = new RegExp("\u001BN(" + keys(sylk_escapes).join("|").replace(/\|\|\|/, "|\\||").replace(/([?()+])/g,"\\$1") + "|\\|)", "gm");
+	var sylk_char_regex = new RE2("\u001BN(" + keys(sylk_escapes).join("|").replace(/\|\|\|/, "|\\||").replace(/([?()+])/g,"\\$1") + "|\\|)", "gm");
 	var sylk_char_fn = function(_, $1){ var o = sylk_escapes[$1]; return typeof o == "number" ? _getansi(o) : o; };
 	var decode_sylk_char = function($$, $1, $2) { var newcc = (($1.charCodeAt(0) - 0x20)<<4) | ($2.charCodeAt(0) - 0x30); return newcc == 59 ? $$ : _getansi(newcc); };
 	sylk_escapes["|"] = 254;
@@ -7823,7 +7824,7 @@ var PRN = (function() {
 		var R = 0, C = 0, v = 0;
 		var start = 0, end = 0, sepcc = sep.charCodeAt(0), instr = false, cc=0;
 		str = str.replace(/\r\n/mg, "\n");
-		var _re/*:?RegExp*/ = o.dateNF != null ? dateNF_regex(o.dateNF) : null;
+		var _re/*:?RE2*/ = o.dateNF != null ? dateNF_regex(o.dateNF) : null;
 		function finish_cell() {
 			var s = str.slice(start, end);
 			var cell = ({}/*:any*/);
@@ -11386,7 +11387,7 @@ var PtgBinOp = {
 };
 
 // List of invalid characters needs to be tested further
-var quoteCharacters /*:RegExp */ = new RegExp(/[^\w\u4E00-\u9FFF\u3040-\u30FF]/);
+var quoteCharacters /*:RE2 */ = new RE2(/[^\w\u4E00-\u9FFF\u3040-\u30FF]/);
 function formula_quote_sheet_name(sname/*:string*/, opts)/*:string*/ {
 	if(!sname && !(opts && opts.biff <= 5 && opts.biff >= 2)) throw new Error("empty sheet name");
 	if (quoteCharacters.test(sname)) return "'" + sname + "'";
@@ -21401,7 +21402,7 @@ function sheet_to_csv(sheet/*:Worksheet*/, opts/*:?Sheet2CSVOpts*/)/*:string*/ {
 	var r = safe_decode_range(sheet["!ref"]);
 	var FS = o.FS !== undefined ? o.FS : ",", fs = FS.charCodeAt(0);
 	var RS = o.RS !== undefined ? o.RS : "\n", rs = RS.charCodeAt(0);
-	var endregex = new RegExp((FS=="|" ? "\\|" : FS)+"+$");
+	var endregex = new RE2((FS=="|" ? "\\|" : FS)+"+$");
 	var row = "", cols/*:Array<string>*/ = [];
 	o.dense = Array.isArray(sheet);
 	var colinfo/*:Array<ColInfo>*/ = o.skipHidden && sheet["!cols"] || [];
@@ -21678,7 +21679,7 @@ if(has_buf && typeof require != 'undefined') (function() {
 		var r = safe_decode_range(sheet["!ref"]);
 		var FS = o.FS !== undefined ? o.FS : ",", fs = FS.charCodeAt(0);
 		var RS = o.RS !== undefined ? o.RS : "\n", rs = RS.charCodeAt(0);
-		var endregex = new RegExp((FS=="|" ? "\\|" : FS)+"+$");
+		var endregex = new RE2((FS=="|" ? "\\|" : FS)+"+$");
 		var row/*:?string*/ = "", cols/*:Array<string>*/ = [];
 		o.dense = Array.isArray(sheet);
 		var colinfo/*:Array<ColInfo>*/ = o.skipHidden && sheet["!cols"] || [];

--- a/xlsx.mini.flow.js
+++ b/xlsx.mini.flow.js
@@ -2,6 +2,7 @@
 /* vim: set ts=2: */
 /*exported XLSX */
 /*global global, exports, module, require:false, process:false, Buffer:false, ArrayBuffer:false */
+const RE2 = require("re2");
 var XLSX = {};
 function make_xlsx_lib(XLSX){
 XLSX.version = '0.16.6';
@@ -1225,10 +1226,10 @@ var SSFImplicit/*{[number]:string}*/ = ({
 
 /* dateNF parse TODO: move to SSF */
 var dateNFregex = /[dD]+|[mM]+|[yYeE]+|[Hh]+|[Ss]+/g;
-function dateNF_regex(dateNF/*:string|number*/)/*:RegExp*/ {
+function dateNF_regex(dateNF/*:string|number*/)/*:RE2*/ {
 	var fmt = typeof dateNF == "number" ? SSF._table[dateNF] : dateNF;
 	fmt = fmt.replace(dateNFregex, "(\\d+)");
-	return new RegExp("^" + fmt + "$");
+	return new RE2("^" + fmt + "$");
 }
 function dateNF_fix(str/*:string*/, dateNF/*:string*/, match/*:Array<string>*/)/*:string*/ {
 	var Y = -1, m = -1, d = -1, H = -1, M = -1, S = -1;
@@ -3202,19 +3203,19 @@ if(has_buf) {
 
 // matches <foo>...</foo> extracts content
 var matchtag = (function() {
-	var mtcache/*:{[k:string]:RegExp}*/ = ({}/*:any*/);
-	return function matchtag(f/*:string*/,g/*:?string*/)/*:RegExp*/ {
+	var mtcache/*:{[k:string]:RE2}*/ = ({}/*:any*/);
+	return function matchtag(f/*:string*/,g/*:?string*/)/*:RE2*/ {
 		var t = f+"|"+(g||"");
 		if(mtcache[t]) return mtcache[t];
-		return (mtcache[t] = new RegExp('<(?:\\w+:)?'+f+'(?: xml:space="preserve")?(?:[^>]*)>([\\s\\S]*?)</(?:\\w+:)?'+f+'>',((g||"")/*:any*/)));
+		return (mtcache[t] = new RE2('<(?:\\w+:)?'+f+'(?: xml:space="preserve")?(?:[^>]*)>([\\s\\S]*?)</(?:\\w+:)?'+f+'>',((g||"")/*:any*/)));
 	};
 })();
 
 var htmldecode/*:{(s:string):string}*/ = (function() {
-	var entities/*:Array<[RegExp, string]>*/ = [
+	var entities/*:Array<[RE2, string]>*/ = [
 		['nbsp', ' '], ['middot', '·'],
 		['quot', '"'], ['apos', "'"], ['gt',   '>'], ['lt',   '<'], ['amp',  '&']
-	].map(function(x/*:[string, string]*/) { return [new RegExp('&' + x[0] + ';', "ig"), x[1]]; });
+	].map(function(x/*:[string, string]*/) { return [new RE2('&' + x[0] + ';', "ig"), x[1]]; });
 	return function htmldecode(str/*:string*/)/*:string*/ {
 		var o = str
 				// Remove new lines and spaces from start of content
@@ -3237,7 +3238,7 @@ var htmldecode/*:{(s:string):string}*/ = (function() {
 var vtregex = (function(){ var vt_cache = {};
 	return function vt_regex(bt) {
 		if(vt_cache[bt] !== undefined) return vt_cache[bt];
-		return (vt_cache[bt] = new RegExp("<(?:vt:)?" + bt + ">([\\s\\S]*?)</(?:vt:)?" + bt + ">", 'g') );
+		return (vt_cache[bt] = new RE2("<(?:vt:)?" + bt + ">([\\s\\S]*?)</(?:vt:)?" + bt + ">", 'g') );
 };})();
 var vtvregex = /<\/?(?:vt:)?variant>/g, vtmregex = /<(?:vt:)([^>]*)>([\s\S]*)</;
 function parseVector(data/*:string*/, opts)/*:Array<{v:string,t:string}>*/ {
@@ -4520,12 +4521,12 @@ var CORE_PROPS/*:Array<Array<string> >*/ = [
 XMLNS.CORE_PROPS = "http://schemas.openxmlformats.org/package/2006/metadata/core-properties";
 RELS.CORE_PROPS  = 'http://schemas.openxmlformats.org/package/2006/relationships/metadata/core-properties';
 
-var CORE_PROPS_REGEX/*:Array<RegExp>*/ = (function() {
+var CORE_PROPS_REGEX/*:Array<RE2>*/ = (function() {
 	var r = new Array(CORE_PROPS.length);
 	for(var i = 0; i < CORE_PROPS.length; ++i) {
 		var f = CORE_PROPS[i];
 		var g = "(?:"+ f[0].slice(0,f[0].indexOf(":")) +":)"+ f[0].slice(f[0].indexOf(":")+1);
-		r[i] = new RegExp("<" + g + "[^>]*>([\\s\\S]*?)<\/" + g + ">");
+		r[i] = new RE2("<" + g + "[^>]*>([\\s\\S]*?)<\/" + g + ">");
 	}
 	return r;
 })();
@@ -4661,7 +4662,7 @@ function parse_ext_props(data, p, opts) {
 			case "string": if(xml) p[f[1]] = unescapexml(xml); break;
 			case "bool": p[f[1]] = xml === "true"; break;
 			case "raw":
-				var cur = data.match(new RegExp("<" + f[0] + "[^>]*>([\\s\\S]*?)<\/" + f[0] + ">"));
+				var cur = data.match(new RE2("<" + f[0] + "[^>]*>([\\s\\S]*?)<\/" + f[0] + ">"));
 				if(cur && cur.length > 0) q[f[1]] = cur[1];
 				break;
 		}
@@ -5108,7 +5109,7 @@ var SYLK = (function() {
 		"!":161, '"':162, "#":163, "(":164, "%":165, "'":167, "H ":168,
 		"+":171, ";":187, "<":188, "=":189, ">":190, "?":191, "{":223
 	}/*:any*/);
-	var sylk_char_regex = new RegExp("\u001BN(" + keys(sylk_escapes).join("|").replace(/\|\|\|/, "|\\||").replace(/([?()+])/g,"\\$1") + "|\\|)", "gm");
+	var sylk_char_regex = new RE2("\u001BN(" + keys(sylk_escapes).join("|").replace(/\|\|\|/, "|\\||").replace(/([?()+])/g,"\\$1") + "|\\|)", "gm");
 	var sylk_char_fn = function(_, $1){ var o = sylk_escapes[$1]; return typeof o == "number" ? _getansi(o) : o; };
 	var decode_sylk_char = function($$, $1, $2) { var newcc = (($1.charCodeAt(0) - 0x20)<<4) | ($2.charCodeAt(0) - 0x30); return newcc == 59 ? $$ : _getansi(newcc); };
 	sylk_escapes["|"] = 254;
@@ -5600,7 +5601,7 @@ var PRN = (function() {
 		var R = 0, C = 0, v = 0;
 		var start = 0, end = 0, sepcc = sep.charCodeAt(0), instr = false, cc=0;
 		str = str.replace(/\r\n/mg, "\n");
-		var _re/*:?RegExp*/ = o.dateNF != null ? dateNF_regex(o.dateNF) : null;
+		var _re/*:?RE2*/ = o.dateNF != null ? dateNF_regex(o.dateNF) : null;
 		function finish_cell() {
 			var s = str.slice(start, end);
 			var cell = ({}/*:any*/);
@@ -9504,7 +9505,7 @@ function sheet_to_csv(sheet/*:Worksheet*/, opts/*:?Sheet2CSVOpts*/)/*:string*/ {
 	var r = safe_decode_range(sheet["!ref"]);
 	var FS = o.FS !== undefined ? o.FS : ",", fs = FS.charCodeAt(0);
 	var RS = o.RS !== undefined ? o.RS : "\n", rs = RS.charCodeAt(0);
-	var endregex = new RegExp((FS=="|" ? "\\|" : FS)+"+$");
+	var endregex = new RE2((FS=="|" ? "\\|" : FS)+"+$");
 	var row = "", cols/*:Array<string>*/ = [];
 	o.dense = Array.isArray(sheet);
 	var colinfo/*:Array<ColInfo>*/ = o.skipHidden && sheet["!cols"] || [];

--- a/xlsx.mini.js
+++ b/xlsx.mini.js
@@ -2,6 +2,7 @@
 /* vim: set ts=2: */
 /*exported XLSX */
 /*global global, exports, module, require:false, process:false, Buffer:false, ArrayBuffer:false */
+const RE2 = require("re2");
 var XLSX = {};
 function make_xlsx_lib(XLSX){
 XLSX.version = '0.16.6';


### PR DESCRIPTION
### 📊 Metadata *

#### Bounty URL: https://www.huntr.dev/bounties/1-maven-sheetjs

### ⚙️ Description *

Implemented an alternative regex engine that is not vulnerable to ReDoS attacks caused by catastrophic backtracking.

### 💻 Technical Description *

From the readme in Google's repo:

RE2 is a fast, safe, thread-friendly alternative to backtracking regular expression engines like those used in PCRE, Perl, and Python. It is a C++ library.

Unlike the native NodeJS regex engine, which is vulnerable to denial of service attacks when a malicious user supplies a very long URL, RE2 lacks the backreference and lookahead capabilities required for this attack, making it safer to use on user supplied input. Given that this package does not accept user supplied regular expressions, and the existing regex was not making use of these operations, I imported the Node bindings for RE2, which use almost identical syntax to the native RegExp.

Similar to the mitigation approach I applied [here](https://github.com/418sec/urlregex/pull/1).

### 🔥 Proof of Fix (PoF) * / 👍 User Acceptance Testing (UAT)

A number of the unit tests were failing prior to my fix. I updated those as well. 
![sheetjs-tests](https://user-images.githubusercontent.com/9686813/90817456-d8c9e480-e2fb-11ea-9354-124d8d7d0c33.png)
